### PR TITLE
fix(docs): Update Python version in Read the Docs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.13"
+    python: "3.10"
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/tests/test_parquetdb.py
+++ b/tests/test_parquetdb.py
@@ -749,13 +749,16 @@ class TestParquetDB(unittest.TestCase):
         incoming_data = [
             {"id_1": 100, "id_2": 10, "field_2": "there"},
             {"id_1": 5, "id_2": 5},
-            {"id_1": 33, "id_2": 13},  # Note: emp_id 4 doesn't exist in employees
+            {
+                "id_1": 33,
+                "id_2": 13,
+            },  # Note: id_1 33, id_2 13 doesn't exist in current_data
             {
                 "id_1": 33,
                 "id_2": 12,
                 "field_2": "field_2",
                 "field_3": "field_3",
-            },  # Note: emp_id 4 doesn't exist in employees
+            },
         ]
 
         incoming_table = ParquetDB.construct_table(incoming_data)
@@ -763,6 +766,8 @@ class TestParquetDB(unittest.TestCase):
         self.db.update(incoming_table, update_keys=["id_1", "id_2"])
 
         table = self.db.read()
+        df = table.to_pandas()
+        logger.debug(f"Dataframe: \n {df}")
         assert table["field_1"].combine_chunks().to_pylist() == [
             "here",
             None,
@@ -1205,7 +1210,7 @@ class TestParquetDB(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    # unittest.main()
 
     # unittest.TextTestRunner().run(TestParquetDB('test_nested_data_handling'))
     # unittest.TextTestRunner().run(TestParquetDB('test_update_maintains_existing_extension_arrays'))
@@ -1225,7 +1230,9 @@ if __name__ == "__main__":
     # unittest.TextTestRunner().run(TestParquetDB('test_update_multi_keys'))
     # unittest.TextTestRunner().run(TestParquetDB("test_transform"))
     # unittest.TextTestRunner().run(TestParquetDB("test_filter_delete"))
-    # unittest.TextTestRunner().run(TestParquetDB("test_drop_duplicates"))
+    # unittest.TextTestRunner().run(TestParquetDB("test_drop_duplicates"))test_update_multi_keys
+
+    unittest.TextTestRunner().run(TestParquetDB("test_update_multi_keys"))
 
     # for x in range(500):
     #     print(f"Iteration {x+1}")


### PR DESCRIPTION
Changed the Python version in the Read the Docs configuration from 3.13 to 3.10 to align with the supported versions for documentation builds. This update ensures compatibility with the current project requirements and maintains the integrity of the documentation process.