### PR TITLE
chore: Rename test job and add documentation build test workflow

### DIFF
--- a/.github/workflows/test-pull-requests.yml
+++ b/.github/workflows/test-pull-requests.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.x'
+          python-version: '3.10'
 
       - name: Install pandoc
         uses: pandoc/actions/setup@v1

--- a/.github/workflows/test-pull-requests.yml
+++ b/.github/workflows/test-pull-requests.yml
@@ -71,10 +71,3 @@ jobs:
           cd docs  # Assuming Sphinx docs are in this directory
           make clean && make html
           echo "build_successful=true" >> $GITHUB_OUTPUT
-
-      - name: Check build status
-        if: steps.build_docs.outputs.build_successful != 'true'
-        run: |
-          echo "Documentation build failed!"
-          exit 1
-          - name: Delete release if failed

--- a/.github/workflows/test-pull-requests.yml
+++ b/.github/workflows/test-pull-requests.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Build documentation
         id: build_docs
-        continue-on-error: true
+        continue-on-error: false
         run: |
           cd docs  # Assuming Sphinx docs are in this directory
           make clean && make html

--- a/.github/workflows/test-pull-requests.yml
+++ b/.github/workflows/test-pull-requests.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 jobs:
-  test:
+  run-tests:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false  # This allows all test environments to complete even if one fails
@@ -41,3 +41,40 @@ jobs:
     - name: Test with pytest
       run: |
         pytest tests/ -v
+
+  run-test-build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Fetch all history
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.x'
+
+      - name: Install pandoc
+        uses: pandoc/actions/setup@v1
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests build python-dotenv
+          pip install setuptools  # Add setuptools which provides distutils
+          pip install .[docs]  # Install package with docs dependencies
+
+      - name: Build documentation
+        id: build_docs
+        continue-on-error: true
+        run: |
+          cd docs  # Assuming Sphinx docs are in this directory
+          make clean && make html
+          echo "build_successful=true" >> $GITHUB_OUTPUT
+
+      - name: Check build status
+        if: steps.build_docs.outputs.build_successful != 'true'
+        run: |
+          echo "Documentation build failed!"
+          exit 1
+          - name: Delete release if failed


### PR DESCRIPTION
Renamed the test job to 'run-tests' for clarity and added a new workflow to build documentation using Sphinx. The new workflow includes steps for setting up Python, installing dependencies, and checking the build status, ensuring that documentation is properly generated and validated during CI.