### PR TITLE
chore: Remove initial project note from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,5 +150,3 @@ Contributions are welcome! Please open an issue or submit a pull request on GitH
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
 
 ---
-
-*Note: This project is in its initial stages. Features and APIs are subject to change. Please refer to the latest documentation and release notes for updates.*


### PR DESCRIPTION
Deleted the note indicating that the project is in its initial stages. This change reflects the project's maturity and reduces clutter in the documentation.