### PR TITLE
chore: Restrict Python version compatibility in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ authors = [
 ]
 description = "ParquetDB is a lightweight database-like system built on top of Apache Parquet files using PyArrow."
 readme = {file = "README.md", content-type = "text/markdown"}  # Ensure this matches the file used
-requires-python = ">=3.8"
+requires-python = ">=3.8,<3.13"
 keywords = ["parquet", "pyarrow", "data", 
             "storage", "schema evolution", "nested and complex data types", 
             "scalable", "database", "python"]


### PR DESCRIPTION
Updated the requires-python field to specify a maximum version of Python 3.12. This change ensures compatibility with the current features and dependencies of the project while preventing issues that may arise from using newer Python versions.

This adjustment is part of ongoing maintenance to keep the project stable and functional.