### PR TITLE
docs: Update README to link to CONTRIBUTING.md for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ If you use ParquetDB in your work, please cite the following paper:
 
 ## Contributing
 
-Contributions are welcome! Please open an issue or submit a pull request on GitHub.
+Contributions are welcome! Please open an issue or submit a pull request on GitHub. More information can be found in the [CONTRIBUTING.md](https://github.com/lllangWV/ParquetDB/blob/main/CONTRIBUTING.md) file.
 
 ## License
 


### PR DESCRIPTION
Added a link to the CONTRIBUTING.md file in the README to provide more detailed information for contributors. This change aims to enhance the onboarding process for new contributors by directing them to relevant guidelines and resources.