### PR TITLE
refactor(parquetdb): Refactor logging

### DIFF
--- a/tests/test_parquetdb.py
+++ b/tests/test_parquetdb.py
@@ -11,6 +11,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.compute as pc
 import pyarrow.parquet as pq
+import pytest
 
 from parquetdb import ParquetDB, config
 from parquetdb.core import types
@@ -19,9 +20,14 @@ from parquetdb.utils import pyarrow_utils
 
 logger = logging.getLogger("tests")
 
-VERBOSE = 2
+VERBOSE = 1
 with open(os.path.join(config.tests_dir, "data", "alexandria_test.json"), "r") as f:
     alexandria_data = json.load(f)
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:__array__ implementation doesn't accept a copy keyword.*:DeprecationWarning"
+)
+
 
 TEMP_DIR = tempfile.mkdtemp()
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4,11 +4,16 @@ from dataclasses import dataclass
 import numpy as np
 import pandas as pd
 import pyarrow as pa
+import pytest
 
 from parquetdb.core.types import (
     PythonObjectArrowType,
     PythonObjectPandasArray,
     PythonObjectPandasDtype,
+)
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:__array__ implementation doesn't accept a copy keyword.*:DeprecationWarning"
 )
 
 


### PR DESCRIPTION
Updated logging levels in the ParquetDB class to use debug instead of info for various operations. This change aims to reduce log verbosity while still providing detailed tracing information during development and debugging.

Additionally, added error logging for unsupported formats and invalid load formats to improve error handling.

No functional changes were made to the core logic of the ParquetDB class.