### PR TITLE
Raise the original exception after logging it in `_normalize`

### DIFF
--- a/parquetdb/core/parquetdb.py
+++ b/parquetdb/core/parquetdb.py
@@ -1330,7 +1330,7 @@ class ParquetDB:
             if new_db_path:
                 dataset_dir.rmdir()
 
-            raise Exception(f"Exception normalizing table. Error Message: {e}")
+            raise
 
     def update_schema(
         self,


### PR DESCRIPTION
It's better to raise the original exception type, so that third parties can handle specific types of exceptions.

Sure, `_normalize` isn't supposed to error, but it seems bad to *prevent* your users from working around any problems that may arise with ParquetDB.