### PR TITLE
Use default factories for `ParquetDBConfig` fields

### DIFF
--- a/parquetdb/core/parquetdb.py
+++ b/parquetdb/core/parquetdb.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import types
 from collections.abc import Iterable
-from dataclasses import dataclass, Field
+from dataclasses import dataclass, field
 from enum import Enum
 from glob import glob
 from pathlib import Path
@@ -161,8 +161,8 @@ class LoadConfig:
 class ParquetDBConfig:
     serialize_python_objects:bool = False
     convert_to_fixed_shape: Optional[bool] = None
-    normalize_config: NormalizeConfig = Field(default_factory=NormalizeConfig)
-    load_config: LoadConfig = Field(default_factory=LoadConfig)
+    normalize_config: NormalizeConfig = field(default_factory=NormalizeConfig)
+    load_config: LoadConfig = field(default_factory=LoadConfig)
 
 class LoadFormat(Enum):
     BATCHES = "batches"

--- a/parquetdb/core/parquetdb.py
+++ b/parquetdb/core/parquetdb.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import types
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, Field
 from enum import Enum
 from glob import glob
 from pathlib import Path
@@ -161,9 +161,9 @@ class LoadConfig:
 class ParquetDBConfig:
     serialize_python_objects:bool = False
     convert_to_fixed_shape: Optional[bool] = None
-    normalize_config: NormalizeConfig = NormalizeConfig()
-    load_config: LoadConfig = LoadConfig()
-    
+    normalize_config: NormalizeConfig = Field(default_factory=NormalizeConfig)
+    load_config: LoadConfig = Field(default_factory=LoadConfig)
+
 class LoadFormat(Enum):
     BATCHES = "batches"
     TABLE = "table"


### PR DESCRIPTION
Depending on your Python version, the fact of using mutable default values for these fields might give a `ValueError`.