### PR TITLE
Release 1.0.2 with the drop-empty fix

### DIFF
--- a/parquetdb/core/parquetdb.py
+++ b/parquetdb/core/parquetdb.py
@@ -1,7 +1,6 @@
 import itertools
 import logging
 import os
-import pathlib
 import shutil
 import types
 from collections.abc import Iterable
@@ -1251,7 +1250,7 @@ class ParquetDB:
                 logger.error("id is not in schema")
                 raise ValueError("id is not in schema")
 
-            def unlink_many(files: Iterable[pathlib.Path]):
+            def unlink_many(files: Iterable[Path]):
                 for file_path in files:
                     if file_path.is_file():
                         file_path.unlink()

--- a/parquetdb/core/parquetdb.py
+++ b/parquetdb/core/parquetdb.py
@@ -1097,7 +1097,7 @@ class ParquetDB:
         columns : List[str], optional
             Column names to remove during normalization.
         drop_empty : bool
-            Whether to delete the dataset, if it has no records after normalization
+            Whether to delete the dataset, if it has no records after normalization.
         transform_callable : Callable, optional
             Custom transformation function to apply during normalization.
         new_db_path : str | Path, optional

--- a/parquetdb/core/parquetdb.py
+++ b/parquetdb/core/parquetdb.py
@@ -1285,7 +1285,7 @@ class ParquetDB:
             if new_db_path:
                 dataset_dir.rmdir()
 
-            raise Exception(f"Exception normalizing table. Error Message: {e}")
+            raise
 
     def update_schema(
         self,

--- a/parquetdb/core/parquetdb.py
+++ b/parquetdb/core/parquetdb.py
@@ -1,6 +1,7 @@
 import itertools
 import logging
 import os
+import pathlib
 import shutil
 import types
 from collections.abc import Iterable
@@ -942,7 +943,7 @@ class ParquetDB:
                 return None
 
         # Apply delete normalization
-        self._normalize(ids=ids, columns=columns, normalize_config=normalize_config)
+        self._normalize(ids=ids, columns=columns, normalize_config=normalize_config, drop_empty=True)
 
         logger.info(f"Deleted data from {self.dataset_name} dataset.")
         return None
@@ -1068,6 +1069,7 @@ class ParquetDB:
         schema: pa.Schema = None,
         ids: List[int] = None,
         columns: List[str] = None,
+        drop_empty: bool = False,
         transform_callable: Callable = None,
         new_db_path: Union[str, Path] = None,
         update_keys: Union[List[str], str] = ["id"],
@@ -1094,6 +1096,8 @@ class ParquetDB:
             Record IDs to remove during normalization.
         columns : List[str], optional
             Column names to remove during normalization.
+        drop_empty : bool
+            Whether to delete the dataset, if it has no records after normalization
         transform_callable : Callable, optional
             Custom transformation function to apply during normalization.
         new_db_path : str | Path, optional
@@ -1247,20 +1251,28 @@ class ParquetDB:
                 logger.error("id is not in schema")
                 raise ValueError("id is not in schema")
 
+            def unlink_many(files: Iterable[pathlib.Path]):
+                for file_path in files:
+                    if file_path.is_file():
+                        file_path.unlink()
+
             # Remove main files to replace with tmp files
             logger.debug(f"Files before renaming: {os.listdir(dataset_dir)}")
             tmp_files = [
                 file for file in dataset_dir.glob(f"tmp-{dataset_name}_*.parquet")
             ]
-            if len(tmp_files) != 0:
-                main_files = dataset_dir.glob(f"{dataset_name}_*.parquet")
-                for file_path in main_files:
-                    if file_path.is_file():
-                        file_path.unlink()
+            main_files = dataset_dir.glob(f"{dataset_name}_*.parquet")
+            if len(tmp_files) == 0:
+                if drop_empty:
+                    logger.info(f"Dropping dataset: {dataset_name}")
+                    unlink_many(main_files)
+                else:
+                    logger.debug(f"Not dropping dataset: {dataset_name}")
+            else:
+                unlink_many(main_files)
 
             logger.debug(f"Files after removing main files: {os.listdir(dataset_dir)}")
 
-            tmp_files = dataset_dir.glob(f"tmp-{dataset_name}_*.parquet")
             for file_path in tmp_files:
                 file_name = file_path.name.replace("tmp-", "")
                 new_file_path = dataset_dir / file_name

--- a/tests/test_parquetdb.py
+++ b/tests/test_parquetdb.py
@@ -65,6 +65,13 @@ class TestParquetDB(unittest.TestCase):
         # deleting the directory and performaing another test
         # time.sleep(0.1)
 
+    def test_drop_empty(self):
+        logger.info("Test dropping emptied table")
+        self.db.create(self.test_data)
+        ids = self.db.read()["id"]
+        self.db.delete(ids)
+        self.assertTrue(self.db.is_empty())
+
     def test_create_and_read(self):
         logger.info("Testing create and read")
         # Test creating data and reading it back


### PR DESCRIPTION
Though I was able to work around bug #55 in 1.0.1 like this:

```python
import pyarrow as pa
from parquetdb import ParquetDB
from pyarrow import compute as pc

db = ParquetDB('parquetdb')
if db.is_empty():
    return
unwanted = pa.table([[]], schema=pa.schema([("id", pa.int64())]))
for datum in data:
    exprs: list[pc.Expression] = []
    for k, v in datum.items():
        expr = pc.field(k) == pc.scalar(v)
        exprs.append(expr)
    selected = db.read(filters=exprs, columns=["id"])
    unwanted = pa.concat_tables([unwanted, selected])
if unwanted.num_rows == db.n_rows:
    db.drop_dataset()
else:
    db.delete(ids=unwanted["id"])
```

This does seem like an unnecessary piece of boilerplate, and might affect performance in apps that delete data often.

So I've made a fork of ParquetDB that applies the real fix, #55, and only that fix. This PR points to that fork, but I don't think you want to merge it, as such, since you've done significant refactoring after 1.0.1.

Please clone my branch 1.0.2 and do a release.

Fixes #58.